### PR TITLE
refactor: removed unused allergy example from transaction-example.fsh, removed hardcoded text.div from allergy-single-example.fsh

### DIFF
--- a/input/fsh/examples/allergy-single-example.fsh
+++ b/input/fsh/examples/allergy-single-example.fsh
@@ -15,5 +15,3 @@ Description: "Juan Dela Cruz has a high criticality, active allergy to Benethami
 * reaction.manifestation.text = "Skin rash"
 * reaction.severity = #severe
 * note.text = "Patient reported rash and swelling after penicillin administration."
-* text.status = #generated
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Juan Dela Cruz has a high criticality, active allergy to Benethamine penicillin.</div>"

--- a/input/fsh/examples/transaction-example.fsh
+++ b/input/fsh/examples/transaction-example.fsh
@@ -87,15 +87,6 @@ Description: "Juan Dela Cruz has an active diagnosis of Type 2 Diabetes Mellitus
 * subject = Reference(Patient/example-patient)
 * encounter = Reference(Encounter/example-encounter)
 
-Instance: example-allergy
-InstanceOf: AllergyIntolerance
-Usage: #example
-Description: "Juan Dela Cruz has a high criticality, active allergy to Benethamine penicillin."
-* code = $sct#294494002 "Benethamine penicillin allergy"
-* criticality = #high
-* clinicalStatus = $allergyintolerance-clinical#active "Active"
-* patient = Reference(Patient/example-patient)
-
 Instance: example-practitioner
 InstanceOf: PHCorePractitioner
 Usage: #example


### PR DESCRIPTION
## Summary

Removed the duplicate `example-allergy` instance from `transaction-example.fsh` and cleaned up hardcoded narrative from `allergy-single-example.fsh` to enable auto-generated narratives by the IG publisher - as mentioned in issue ticket #322 

## Related Issue

Closes #322

## Type of Work

- [ ] Profile
- [x] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [x] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

- **Removed** `example-allergy` instance from `transaction-example.fsh` — this example was using the base `AllergyIntolerance` profile instead of `PHCoreAllergyIntolerance` and was missing critical elements (`verificationStatus`, `onsetDateTime`, `reaction`, `note`).
- **Updated** `allergy-single-example.fsh`:
  - Removed hardcoded `text.status` and `text.div` fields to allow the IG publisher to auto-generate consistent narratives from structured data
  - Retained all clinical details: patient reference, allergen (Benethamine penicillin), high criticality, active status, reaction with severity, and clinical note
  - Confirmed conformance to `PHCoreAllergyIntolerance` profile

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [x] Examples validate
- [x] Terminology checked
- [x] Links verified
- [ ] Other:

## Reviewer Notes

- This PR aligns with the global narrative standardization effort (#305). All examples should remove hardcoded `text.div` to enable consistent auto-generation.
- The `allergy-single-example` is now the single source of truth for AllergyIntolerance examples in this IG, fully conformant to the `PHCoreAllergyIntolerance` profile with complete clinical context.
- No functional changes to example data; consolidation and cleanup only.

## Preview / Screenshots

https://build.fhir.org/ig/eabuenaventura/eab-ph-core/branches/322-allergyintolerance-examples-alignment/en/