### PR TITLE
refactor: removed unused immunization instance from transaction-example.fsh and hardcoded text.div from immunization-single-example.fsh

### DIFF
--- a/input/fsh/examples/immunization-single-example.fsh
+++ b/input/fsh/examples/immunization-single-example.fsh
@@ -50,6 +50,3 @@ Description: "Juan Dela Cruz received a completed intramuscular influenza (H5N1-
 * protocolApplied.targetDisease = $sct#772828001 "Influenza caused by Influenza A virus subtype H5N1"
 * protocolApplied.targetDisease.text = "Influenza H5N1"
 * protocolApplied.doseNumberPositiveInt = 1
-
-* text.status = #generated
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\">Juan Dela Cruz received a completed intramuscular influenza (H5N1-1203) vaccine in the left arm on January 10, 2013, at Philippine General Hospital. The vaccine lot number was AAJN11K and was privately funded. Dose 1 was administered by Dr. Maria Clara Santos.</div>"

--- a/input/fsh/examples/transaction-example.fsh
+++ b/input/fsh/examples/transaction-example.fsh
@@ -101,30 +101,6 @@ Description: "Juan Dela Cruz has a high criticality, active allergy to Benethami
 * clinicalStatus = $allergyintolerance-clinical#active "Active"
 * patient = Reference(Patient/example-patient)
 
-Instance: example-immunization
-InstanceOf: PHCoreImmunization
-Description: "Flu shot for H5N1-1203."
-Usage: #example
-* doseQuantity = 5 'mg'
-* encounter = Reference(Encounter/encounter-single-example)
-* expirationDate = "2015-02-15"
-* fundingSource = $immunization-funding-source#private
-* identifier.system = "urn:ietf:rfc:3986"
-* identifier.value = "urn:oid:1.3.6.1.4.1.21367.2005.3.7.1234"
-* isSubpotent = true
-* lotNumber = "AAJN11K"
-* note.text = "Notes on adminstration of vaccine"
-* occurrenceDateTime = "2013-01-10"
-* patient = Reference(Patient/example-patient)
-* performer.actor = Reference(Practitioner/example-practitioner)
-* performer.function = $v2-0443#OP
-* primarySource = true
-* route = $v3-RouteOfAdministration#IM "Injection, intramuscular"
-* site = $v3-ActSite#LA "left arm"
-* status = #completed
-* vaccineCode = http://hl7.org/fhir/sid/cvx#123
-* vaccineCode.text = "influenza, H5N1-1203"
-
 Instance: example-practitioner
 InstanceOf: PHCorePractitioner
 Usage: #example


### PR DESCRIPTION
## Summary

Align immunization examples by removing redundant narrative text and consolidating example instances. The changes remove the hardcoded narrative text.div and the redundant immunization example on transaction-example.fsh

## Related Issue

Closes #323

## Type of Work

- [x] Example
- [ ] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [ ] CI/Build Infrastructure
- [ ] Other

## Changes Made

**Removed hardcoded narrative from `immunization-single-example.fsh`:**
- Removed `text.status = #generated` 
- Removed `text.div` containing hardcoded HTML narrative (Juan Dela Cruz vaccine narrative)
- The narrative will now be auto-generated by the IG build process

**Consolidated immunization examples in `transaction-example.fsh`:**
- Removed the `example-immunization` instance that was defined within the transaction example
- This instance is now referenced from `immunization-single-example.fsh` instead
- Reduces duplication and maintains a single source of truth for the immunization example

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [x] Examples validate
- [x] Terminology checked
- [ ] Links verified
- [ ] Other:

## Reviewer Notes

Key areas for review:
- Verify that removing the hardcoded narrative doesn't affect the rendered output (should auto-generate properly)
- Confirm that consolidating the immunization example doesn't break transaction example functionality
- Ensure narrative generation produces expected output without manual div elements
- The referenced immunization example in transaction-example should point to the correct resource in immunization-single-example

## Preview / Screenshots

https://build.fhir.org/ig/eabuenaventura/eab-ph-core/branches/323-immunization-examples-alignment/