### PR TITLE
ci: upgrade Publisher and bound terminology validation

### DIFF
--- a/.github/workflows/build-ig.yml
+++ b/.github/workflows/build-ig.yml
@@ -67,6 +67,7 @@ jobs:
           key: ig-publisher-2.2.7-${{ runner.os }}
 
       - name: Build IG
+        timeout-minutes: 15
         run: |
           mkdir -p ./input-cache
           # Pin to publisher 2.2.7 — 2.2.8+ introduces breaking changes that
@@ -76,7 +77,11 @@ jobs:
             curl -L https://github.com/HL7/fhir-ig-publisher/releases/download/2.2.7/publisher.jar -o ./input-cache/publisher.jar
           fi
           chmod +x ./_genonce.sh
-          ./_genonce.sh
+          # Keep CI deterministic: the public terminology server can block for
+          # minutes per lookup and has previously stretched this step beyond
+          # 90 minutes. Terminology validation remains available in local or
+          # dedicated online builds; CI still runs the publisher and QA gate.
+          ./_genonce.sh -tx n/a
           
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ig.yml
+++ b/.github/workflows/build-ig.yml
@@ -58,30 +58,38 @@ jobs:
           sudo gem install jekyll
           sudo npm install -g fsh-sushi
 
-      # Cache the IG Publisher JAR. If you ever bump the publisher version,
-      # update the key below (e.g. 2.2.7 → 2.2.8) so the new JAR is fetched.
+      # Cache the pinned IG Publisher JAR. The version is also part of the
+      # terminology-cache key because publisher upgrades can change validation
+      # and cache behavior.
       - name: Cache IG Publisher
         uses: actions/cache@v4
         with:
           path: ./input-cache/publisher.jar
-          key: ig-publisher-2.2.7-${{ runner.os }}
+          key: ig-publisher-2.3.4-${{ runner.os }}
+
+      - name: Cache terminology data
+        uses: actions/cache@v4
+        with:
+          path: ./input-cache/txcache
+          key: txcache-${{ runner.os }}-publisher-2.3.4-${{ hashFiles('sushi-config.yaml', 'input/fsh/**/*.fsh') }}
+          restore-keys: |
+            txcache-${{ runner.os }}-publisher-2.3.4-
 
       - name: Build IG
         timeout-minutes: 15
         run: |
           mkdir -p ./input-cache
-          # Pin to publisher 2.2.7 — 2.2.8+ introduces breaking changes that
-          # cause build failures. Local builds via _updatePublisher.sh still
-          # fetch latest; this pin applies to CI only.
+          # Pin CI to a reviewed Publisher release for reproducible validation.
           if [ ! -f ./input-cache/publisher.jar ]; then
-            curl -L https://github.com/HL7/fhir-ig-publisher/releases/download/2.2.7/publisher.jar -o ./input-cache/publisher.jar
+            curl --fail --location --show-error \
+              https://github.com/HL7/fhir-ig-publisher/releases/download/2.3.4/publisher.jar \
+              --output ./input-cache/publisher.jar
           fi
-          chmod +x ./_genonce.sh
-          # Keep CI deterministic: the public terminology server can block for
-          # minutes per lookup and has previously stretched this step beyond
-          # 90 minutes. Terminology validation remains available in local or
-          # dedicated online builds; CI still runs the publisher and QA gate.
-          ./_genonce.sh -tx n/a
+          export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} -Dfile.encoding=UTF-8"
+          # Terminology validation remains mandatory. Use the explicit HTTPS R4
+          # endpoint and restored terminology cache; fail within the step timeout
+          # if the service cannot complete validation instead of disabling it.
+          java -jar ./input-cache/publisher.jar -ig . -tx https://tx.fhir.org/r4
           
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Keep PH Core terminology validation enabled while preventing the public terminology service from making CI run for hours.

The triggering run spent `1h 40m 43s` in `Build IG`. Its log showed Publisher 2.2.7 connecting to `http://tx.fhir.org` with an empty terminology cache, followed by repeated terminology operations exceeding 60 seconds. The workflow configuration originated in commit [`929b5eb`](https://github.com/UPM-NTHC/ph-core/commit/929b5eb097dba029949c5c8f0c1b5f9006e5ef29) / PR #312.

This PR updates CI to Publisher 2.3.4, which includes terminology-cache fixes and validation performance improvements, retains online terminology validation through the explicit HTTPS R4 endpoint, restores a reusable terminology cache, and bounds the build step at 15 minutes.

## Related Issue

Closes #364

## Type of Work

- [ ] Profile
- [ ] Extension
- [ ] CodeSystem
- [ ] ValueSet
- [ ] ConceptMap
- [ ] Example
- [ ] Narrative Page
- [ ] Documentation
- [ ] Test Script
- [x] CI/Build Infrastructure
- [ ] Other

## Changes Made

- Upgrade the pinned FHIR IG Publisher from 2.2.7 to 2.3.4 and update its cache key.
- Cache `input-cache/txcache`, keyed by runner OS, Publisher version, and terminology-relevant source hashes.
- Restore the latest compatible 2.3.4 terminology cache when the exact source hash is new.
- Run Publisher directly with `-tx https://tx.fhir.org/r4` so terminology validation remains mandatory and cannot silently fall back to `-tx n/a` through `_genonce.sh` connectivity inference.
- Keep a 15-minute timeout on `Build IG`; unhealthy terminology validation now fails clearly within the bound instead of running for hours.
- Preserve artifact upload and the existing `qa.json` QA gate.

## Validation / Testing

- [x] IG builds successfully (`sushi .` with 0 errors)
- [x] Examples validate
- [x] Terminology checked
- [x] Links verified
- [x] Other: Workflow YAML parses successfully and the scoped diff passes `git diff --check`.

Authoritative GitHub Actions validation:

- [Cold-cache run 34327452387, attempt 1](https://github.com/UPM-NTHC/ph-core/actions/runs/34327452387/attempts/1): passed in `4m 48s`; `Build IG` completed in `3m 25s`; Publisher 2.3.4 connected to `https://tx.fhir.org/r4`; `0` errors and `0` broken links; artifacts uploaded; terminology and Publisher caches saved.
- [Cache-hit rerun 34327452387, attempt 2](https://github.com/UPM-NTHC/ph-core/actions/runs/34327452387/attempts/2): passed in `4m 9s`; restored Publisher 2.3.4 and `16` terminology-cache files; online terminology validation remained enabled; `0` errors and `0` broken links.

## Reviewer Notes

This deliberately does **not** use `-tx n/a`. Terminology inference and validation remain part of the required CI result. The timeout is a failure boundary, not a fallback: if the terminology service cannot complete the build, the check fails instead of silently weakening validation.

The cache is an optimization and resilience measure, not a replacement for online terminology validation. `-resetTx` and `-resetTxErrors` remain available for deliberate cache maintenance when troubleshooting terminology changes.

## Preview / Screenshots

https://build.fhir.org/ig/UP-Manila-SILab/ph-core/branches/fix-364-ci-build-timeout/
